### PR TITLE
Fixes Firewall and Updates Defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,9 @@
 # roles/dnsmasq/defaults/main.yml
 ---
-dnsmasq_listen_address: 127.0.0.1
-dnsmasq_domain_needed: false
-dnsmasq_bogus_priv: false
-dnsmasq_authoritative: false
-dnsmasq_expand_hosts: false
+dnsmasq_listen_address: "{{ ansible_default_ipv4.address }}"
+dnsmasq_tftp_server: "{{ ansible_default_ipv4.address }}"
+dnsmasq_boot_file: 'pxelinux.0'
+dnsmasq_domain_needed: true
+dnsmasq_bogus_priv: true
+dnsmasq_authoritative: true
+dnsmasq_expand_hosts: true

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -1,0 +1,15 @@
+---
+- name: Open firewalld port for DNS TCP
+  firewalld: port=53/tcp permanent=false state=enabled
+  # in case this is a server where firewalld is turned off
+  ignore_errors: yes
+
+- name: Open firewalld port for DNS UDP
+  firewalld: port=53/udp permanent=false state=enabled
+  # in case this is a server where firewalld is turned off
+  ignore_errors: yes
+
+- name: Open firewalld port for DHCP
+  firewalld: port=67/udp permanent=false state=enabled
+  # in case this is a server where firewalld is turned off
+  ignore_errors: yes

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -1,0 +1,26 @@
+---
+- name: Get iptables rules
+  command: iptables -L --wait
+  register: iptablesrules
+  always_run: yes
+
+- name: Enable iptables at boot
+  service: name=iptables enabled=yes state=started
+
+- name: Open DNS TCP port with iptables
+  command: iptables -I INPUT 1 -p tcp --dport 53 -j ACCEPT -m comment --comment "dns-tcp"
+  when: "'dns-tcp' not in iptablesrules.stdout"
+  notify:
+    - Save iptables rules
+
+- name: Open DNS UDP port with iptables
+  command: iptables -I INPUT 1 -p udp --dport 53 -j ACCEPT -m comment --comment "dns-udp"
+  when: "'dns-udp' not in iptablesrules.stdout"
+  notify:
+    - Save iptables rules
+
+- name: Open DHCP Server port with iptables
+  command: iptables -I INPUT 1 -p udp --dport 67 -j ACCEPT -m comment --comment "dhcp-server"
+  when: "'dhcp-server' not in iptablesrules.stdout"
+  notify:
+    - Save iptables rules

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,27 +21,32 @@
     enabled: yes
   tags: dnsmasq
 
-- name: Apply DNS firewall rules
-  firewalld:
-    service: dns
-    permanent: true
-    state: enabled
-    zone: public
-  with_items:
-    - 'dns'
-  notify:
-    restart firewalld
-  tags: dnsmasq
+- name: Determine if firewalld installed
+  command: "rpm -q firewalld"
+  register: s
+  changed_when: false
+  failed_when: false
+  always_run: yes
 
-- name: Apply DHCP firewall rules
-  firewalld:
-    service: dhcp
-    permanent: true
-    state: enabled
-    zone: public
-  with_items:
-    - 'dhcp'
-  when: dnsmasq_dhcp_ranges is defined
-  notify:
-    restart firewalld
-  tags: dnsmasq
+- name: Set the has_firewalld fact
+  set_fact:
+    has_firewalld: true
+  when: s.rc == 0
+
+- name: Determine if iptables-services installed
+  command: "rpm -q iptables-services"
+  register: s
+  changed_when: false
+  failed_when: false
+  always_run: yes
+
+- name: Set the has_iptables fact
+  set_fact:
+    has_iptables: true
+  when: s.rc == 0
+
+- include: firewalld.yml
+  when: has_firewalld
+
+- include: iptables.yml
+  when: not has_firewalld and has_iptables


### PR DESCRIPTION
Previously, iptables/firewalld was not properly setting
DHCP firewall rules. This would cause cluster nodes to not
be PXE provisioned. Additionally, several defaults were updated
so they would not need to be exposed to group_vars.